### PR TITLE
Pin gradio to 3.50.2

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -8,5 +8,5 @@ build:
     - "ffmpeg"
     - "imagemagick"
   python_packages:
-    - "gradio"
+    - "gradio==3.50.2"
 predict: "predict.py:Predictor"


### PR DESCRIPTION
gradio >= 4 depends on pydantic >= 2, which is incompatible with Cog.